### PR TITLE
Fix bug with empty first row and headers

### DIFF
--- a/src/Flow/ETL/Adapter/CSV/League/CSVLoader.php
+++ b/src/Flow/ETL/Adapter/CSV/League/CSVLoader.php
@@ -69,6 +69,10 @@ final class CSVLoader implements Loader
      */
     public function load(Rows $rows) : void
     {
+        if ($rows->empty()) {
+            return;
+        }
+
         if ($this->withHeader && !$this->headerAdded) {
             $this->writer()->insertOne($rows->first()->entries()->map(fn (Entry $entry) => $entry->name()));
             $this->headerAdded = true;

--- a/tests/Flow/ETL/Adapter/CSV/Tests/Integration/League/CSVLoaderTest.php
+++ b/tests/Flow/ETL/Adapter/CSV/Tests/Integration/League/CSVLoaderTest.php
@@ -104,4 +104,30 @@ CSV,
             \unlink($path);
         }
     }
+
+    public function test_loading_csv_files_with_empty_row() : void
+    {
+        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
+
+        $loader = CSV::to_file($path, 'w+', $withHeader = true);
+
+        $loader->load(new Rows(
+        ));
+
+        $loader->load(new Rows(
+            Row::create(new Row\Entry\IntegerEntry('id', 1), new Row\Entry\StringEntry('name', 'Norbert')),
+        ));
+
+        $this->assertStringContainsString(
+            <<<'CSV'
+id,name
+1,Norbert
+CSV,
+            \file_get_contents($path)
+        );
+
+        if (\file_exists($path)) {
+            \unlink($path);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>CSV Loader fails to write headers when first Rows object is empty</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

When using Flow PHP with filtering I found a bug with CSV Loader. When first set of Rows are empty, the loader fails. 
Result of the test that has been added without a fix:

```
There was 1 error:

1) Flow\ETL\Adapter\CSV\Tests\Integration\League\CSVLoaderTest::test_loading_csv_files_with_empty_row
Flow\ETL\Exception\RuntimeException: First row does not exist in empty collection

/Users/mczarnecki/projects/etl-adapter-csv/vendor/flow-php/etl/src/Flow/ETL/Rows.php:248
/Users/mczarnecki/projects/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/League/CSVLoader.php:73
/Users/mczarnecki/projects/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/League/CSVLoaderTest.php:114
```
<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->